### PR TITLE
Use valid category value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Blasterbug
 maintainer=Blasterbug <benjamin.sientzoff@yahoo.fr>
 sentence=DistNx is a Arduino library to use DIST-Nx sensor
 paragraph=DistNx is a Arduino library to use DIST-Nx sensor from Mindsensors.com
-category=Sensing
+category=Sensors
 url=https://github.com/blasterbug/DistNx
 architectures=*


### PR DESCRIPTION
Use of category other than the valid values specified in the[ Arduino Library specification](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format) causes the warning:
```
WARNING: Category 'Sensing' in library DistNx is not valid. Setting to 'Uncategorized'
```
on every compile when using Arduino IDE 1.6.6 or newer.